### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to help with college applications",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the missing GitHub Skills activity that was announced by the principal.

## Changes
- Added "GitHub Skills" activity to the activities dictionary in `app.py`
- Activity includes description about practical coding and collaboration skills
- Mentions GitHub Certifications program for college applications
- Schedule: Wednesdays, 3:30 PM - 5:00 PM
- Max participants: 25 students

## Resolves
Fixes #6 

## Timeline
This addresses a time-sensitive issue as registrations were supposed to close by the end of this week. Students can now sign up for the GitHub Skills activity as announced.